### PR TITLE
Allow whitesourceOrgToken to be defined by the env var WHITESOURCE_PASSWORD

### DIFF
--- a/src/main/scala/sbtwhitesource/WhiteSourcePlugin.scala
+++ b/src/main/scala/sbtwhitesource/WhiteSourcePlugin.scala
@@ -144,7 +144,7 @@ object WhiteSourcePlugin extends AutoPlugin {
           if (whitesourceFailOnError.value) sys.error(msg) else log.debug(msg)
           ""
       }
-      (whitesourceOrgToken in ThisBuild).?.value getOrElse pass
+      (whitesourceOrgToken in ThisBuild).?.value orElse sys.env.get("WHITESOURCE_PASSWORD") getOrElse pass
     },
     whitesourceCheckPolicies :=
         new CheckPoliciesAction(


### PR DESCRIPTION
Useful to run on Travis CI