### PR TITLE
Remove the pecoff4j exclusion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,6 @@ libraryDependencies += Defaults.sbtPluginExtra(
 val whitesourceVersion = "2.6.9"
 
 libraryDependencies += "org.whitesource" % "wss-agent-api"        % whitesourceVersion
-// Exclude pecoff library which is not on maven central and used only for .Net
 libraryDependencies += "org.whitesource" % "wss-agent-api-client" % whitesourceVersion
 libraryDependencies += "org.whitesource" % "wss-agent-report"     % whitesourceVersion
 

--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,8 @@ val whitesourceVersion = "2.6.9"
 
 libraryDependencies += "org.whitesource" % "wss-agent-api"        % whitesourceVersion
 // Exclude pecoff library which is not on maven central and used only for .Net
-libraryDependencies += "org.whitesource" % "wss-agent-api-client" % whitesourceVersion exclude("org.boris", "pecoff4j")
-libraryDependencies += "org.whitesource" % "wss-agent-report"     % whitesourceVersion exclude("org.boris", "pecoff4j")
+libraryDependencies += "org.whitesource" % "wss-agent-api-client" % whitesourceVersion
+libraryDependencies += "org.whitesource" % "wss-agent-report"     % whitesourceVersion
 
 mimaPreviousArtifacts := Set {
   val m = organization.value %% moduleName.value % "0.1.7"


### PR DESCRIPTION
Whitesource no longer depends on this unavailable artifact, instead publishing it to Maven Central under their own group ID:

http://repo1.maven.org/maven2/org/whitesource/pecoff4j/0.0.2.1/