### PR TITLE
Deprecate whitesourceIgnoreTestScopeDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run `whitesourceUpdate` task to upload your projects' info to WhiteSource.
 
 ## Configuration
 
-This plugin is a port of [whitesource-maven-plugin][] to sbt, providing very similar options and features.
+This plugin is a port of [whitesource-maven-plugin][] v3.2.4 to sbt, providing very similar options and features.
 
 [whitesource-maven-plugin]: https://github.com/whitesource/maven-plugin
 

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,12 @@ mimaPreviousArtifacts := Set {
     m
 }
 
+import com.typesafe.tools.mima.core._
+mimaBinaryIssueFilters ++= Seq(
+  // ProjectConfig is internal API (it has no key)
+  ProblemFilters.exclude[DirectMissingMethodProblem]("sbtwhitesource.ProjectConfig.*")
+)
+
 bintrayOrganization := Some("sbt")
 bintrayRepository   := "sbt-plugin-releases"
 

--- a/src/main/scala/sbtwhitesource/WhiteSource.scala
+++ b/src/main/scala/sbtwhitesource/WhiteSource.scala
@@ -39,7 +39,6 @@ final class ProjectConfig(
     val onlyDirectDependencies: Boolean,
     val libraryDependencies: Seq[ModuleID],
     val updateReport: UpdateReport,
-    val ignoreTestScopeDependencies: Boolean,
     val projectToken: String,
     val ignore: Boolean,
     val includes: Vector[String],

--- a/src/main/scala/sbtwhitesource/WhiteSourcePlugin.scala
+++ b/src/main/scala/sbtwhitesource/WhiteSourcePlugin.scala
@@ -60,6 +60,7 @@ object WhiteSourcePlugin extends AutoPlugin {
     val whitesourceIgnore: SettingKey[Boolean] =
       settingKey("If set to true this module will be ignored. Overrides any include patterns.")
 
+    @deprecated("Not used", "0.1.13")
     val whitesourceIgnoreTestScopeDependencies: SettingKey[Boolean] =
       settingKey("If set to false test scope dependencies are included.")
 
@@ -186,7 +187,6 @@ object WhiteSourcePlugin extends AutoPlugin {
     whitesourceOnlyDirectDependencies.value,
     libraryDependencies.value,
     update.value,
-    whitesourceIgnoreTestScopeDependencies.value,
     whitesourceProjectToken.value,
     whitesourceIgnore.value,
     whitesourceIncludes.value,


### PR DESCRIPTION
Looks like the parameter 'ignoreTestScopeDependencies' was never used in 
the original maven plugin, which is why this sbt-plugin port didn't use it.

Indeed that maven plugin parameter was later removed:

https://github.com/whitesource/maven-plugin/commit/a21936b8bffe6a4aa0958394cb2d122269c5d763

Also make a note of the version of the maven plugin originally used for the port.

Fixes #48