### PR TITLE
Ignore 'skip in publish' projects automatically

### DIFF
--- a/src/main/scala/sbtwhitesource/WhiteSourcePlugin.scala
+++ b/src/main/scala/sbtwhitesource/WhiteSourcePlugin.scala
@@ -188,7 +188,7 @@ object WhiteSourcePlugin extends AutoPlugin {
     libraryDependencies.value,
     update.value,
     whitesourceProjectToken.value,
-    whitesourceIgnore.value,
+    whitesourceIgnore.value || (skip in publish).value,
     whitesourceIncludes.value,
     whitesourceExcludes.value,
     whitesourceIgnoredScopes.value


### PR DESCRIPTION
It would be neater to set the default value of `whitesourceIgnore`
based on `skip in publish`, but `skip` is a `task` rather than a
`setting`, so that doesn't seem possible.

Fixes #53.