### PR TITLE
Support sbt 1.3.0 for Akka

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,8 @@ libraryDependencies += "org.whitesource" % "wss-agent-api"        % whitesourceV
 libraryDependencies += "org.whitesource" % "wss-agent-api-client" % whitesourceVersion
 libraryDependencies += "org.whitesource" % "wss-agent-report"     % whitesourceVersion
 
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % Test
+
 mimaPreviousArtifacts := Set {
   val m = organization.value %% moduleName.value % "0.1.7"
   val sbtBinV = (sbtBinaryVersion in pluginCrossBuild).value

--- a/src/main/scala/sbtwhitesource/WhiteSource.scala
+++ b/src/main/scala/sbtwhitesource/WhiteSource.scala
@@ -53,7 +53,15 @@ final class ProjectConfig(
 final case class WhiteSourceException(message: String = null, cause: Exception = null)
     extends RuntimeException(message, cause)
 
+sealed case class ModuleInfo(
+  groupId: String,
+  artifactId: String,
+  version: String,
+  artifactAndJar: Option[(Artifact, File)]
+)
+
 sealed abstract class BaseAction(config: Config, childConfigs: Vector[ProjectConfig]) {
+  import BaseAction._
   val agentType: String    = "maven-plugin"     // TODO: use "sbt-plugin" or "sbt-whitesource"
   val agentVersion: String = "2.4.9" // "0.1.0-SNAPSHOT" // TODO: Extract this from the build.
   import config._
@@ -220,53 +228,6 @@ sealed abstract class BaseAction(config: Config, childConfigs: Vector[ProjectCon
     dependencyInfos
   }
 
-  sealed case class ModuleInfo(
-      groupId: String,
-      artifactId: String,
-      version: String,
-      artifactAndJar: Option[(Artifact, File)]
-  )
-
-  /* Under sbt-coursier it's possible to have multiple ModuleInfo for the same (groupId, artifactId),
-   * where there is no difference between them,
-   * or the difference is one has artifacts of type "jar" and the other of type "bundle".
-   *
-   * For this last case we 'upgrade' "jar" to "bundle".
-   */
-  private def mergeModuleInfo(m1: ModuleInfo, m2: ModuleInfo): Option[ModuleInfo] = {
-
-    def moduleInfoToTuple(m: ModuleInfo) = (m.groupId, m.artifactId, m.version)
-
-    def artifactToTuple(a: Artifact) =
-      (a.name, a.extension, a.configurations, a.url, a.extraAttributes)
-
-    if (moduleInfoToTuple(m1) != moduleInfoToTuple(m2)) None else {
-      (m1.artifactAndJar, m2.artifactAndJar) match {
-        case (None, Some(_))                  => None
-        case (Some(_), None)                  => None
-        case (None, None)                     => Some(m1)
-        case (Some((a1, f1)), Some((a2, f2))) =>
-          val artifactAndJar = if (artifactToTuple(a1) != artifactToTuple(a2)) None else {
-            val mergedType = Set(a1.`type`, a2.`type`).toSeq.sorted match {
-              case Seq(t1)              => Some(t1)
-              case Seq("bundle", "jar") => Some("bundle") // 'upgrade' "jar" to "bundle"
-              case _                    => None
-            }
-            val mergedClassifierAndFile = Set((a1.classifier, f1), (a2.classifier, f2)).toSeq.sorted match {
-              case Seq(x)                                  => Some(x)
-              case Seq(x @ (None, _), (Some("native"), _)) => Some(x) // discard "native" classifier
-              case _                                       => None
-            }
-            for {
-              tpe <- mergedType
-              (classifier, file) <- mergedClassifierAndFile
-            } yield a1.withType(tpe).withClassifier(classifier) -> file
-          }
-          artifactAndJar map (artifactAndJar => m1.copy(artifactAndJar = Some(artifactAndJar)))
-      }
-    }
-  }
-
   private def getDependencyInfo(m: ModuleInfo, scope: MavenScope, optional: Boolean): DependencyInfo = {
     val info = new DependencyInfo()
     info setGroupId m.groupId
@@ -359,6 +320,47 @@ sealed abstract class BaseAction(config: Config, childConfigs: Vector[ProjectCon
       log trace e
     }
   }
+}
+
+object BaseAction {
+  /* Under sbt-coursier it's possible to have multiple ModuleInfo for the same (groupId, artifactId),
+   * where there is no difference between them,
+   * or the difference is one has artifacts of type "jar" and the other of type "bundle".
+   *
+   * For this last case we 'upgrade' "jar" to "bundle".
+   */
+  private[sbtwhitesource] def mergeModuleInfo(m1: ModuleInfo, m2: ModuleInfo): Option[ModuleInfo] = {
+    def moduleInfoToTuple(m: ModuleInfo) = (m.groupId, m.artifactId, m.version)
+
+    def artifactToTuple(a: Artifact) =
+      (a.name, a.extension, a.configurations, a.extraAttributes)
+
+    if (moduleInfoToTuple(m1) != moduleInfoToTuple(m2)) None else {
+      (m1.artifactAndJar, m2.artifactAndJar) match {
+        case (None, Some(_))                  => None
+        case (Some(_), None)                  => None
+        case (None, None)                     => Some(m1)
+        case (Some((a1, f1)), Some((a2, f2))) =>
+          val artifactAndJar = if (artifactToTuple(a1) != artifactToTuple(a2)) None else {
+            val mergedType = Set(a1.`type`, a2.`type`).toSeq.sorted match {
+              case Seq(t1)              => Some(t1)
+              case Seq("bundle", "jar") => Some("bundle") // 'upgrade' "jar" to "bundle"
+              case _                    => None
+            }
+            val mergedClassifierAndFile = Set((a1.classifier, f1), (a2.classifier, f2)).toSeq.sorted match {
+              case Seq(x)                                  => Some(x)
+              case Seq(x @ (None, _), (Some("native"), _)) => Some(x) // discard "native" classifier
+              case _                                       => None
+            }
+            for {
+              tpe <- mergedType
+              (classifier, file) <- mergedClassifierAndFile
+            } yield a1.withType(tpe).withClassifier(classifier) -> file
+          }
+          artifactAndJar map (artifactAndJar => m1.copy(artifactAndJar = Some(artifactAndJar)))
+       }
+     }
+   }
 }
 
 final class CheckPoliciesAction(config: Config, childConfigs: Vector[ProjectConfig]) extends BaseAction(config, childConfigs) {

--- a/src/test/scala/sbtwhitesource/BaseActionSpec.scala
+++ b/src/test/scala/sbtwhitesource/BaseActionSpec.scala
@@ -1,0 +1,25 @@
+package sbtwhitesource
+
+import java.net.URL
+
+import sbt.Artifact
+
+import org.scalatest.WordSpec
+import org.scalatest.Matchers
+
+class BaseActionSpec extends WordSpec with Matchers {
+  "The base action" should {
+    "merge standard and native jars of the same artifacts" in {
+      val nativeUrl = new URL("https://repo1.maven.org/maven2/com/github/jnr/jffi/1.2.16/jffi-1.2.16-native.jar")
+      val nativeArtifact: Artifact = Artifact("com.github", "jar", "jar", Some("native"), Vector(), Some(nativeUrl))
+      val native = ModuleInfo("com.github", "jffi", "1.2.16", Some((nativeArtifact, null)))
+      
+      val javaUrl = new URL("https://repo1.maven.org/maven2/com/github/jnr/jffi/1.2.16/jffi-1.2.16.jar")
+      val javaArtifact: Artifact = Artifact("com.github", "jar", "jar", None, Vector(), Some(javaUrl))
+      val java = ModuleInfo("com.github", "jffi", "1.2.16", Some((javaArtifact, null)))
+      
+      BaseAction.mergeModuleInfo(native, java) should be(Some(java))
+      BaseAction.mergeModuleInfo(java, native) should be(Some(java))
+    }
+  }
+}


### PR DESCRIPTION
When updating Akka to sbt 1.3.0 (https://github.com/akka/akka/pull/26935), sbt-whitesource fails due to the problem reproduced here.

I'm not quite sure this is really a valid situation - perhaps we should verify that?

If so we can fix it in whitesource, otherwise we should prevent it earlier ;)