### PR TITLE
Fix module deduplication

### DIFF
--- a/src/main/scala/sbtwhitesource/WhiteSource.scala
+++ b/src/main/scala/sbtwhitesource/WhiteSource.scala
@@ -340,13 +340,13 @@ object BaseAction {
         case (Some((a1, f1)), Some((a2, f2))) =>
           if (a1.classifier == a2.classifier && a1.`type` == a2.`type`)
             Some(m1)
-          else if (a1.classifier == Some("native") && a2.classifier == None)
+          else if (a1.classifier.isDefined && a2.classifier.isEmpty)
             Some(m2)
-          else if (a1.classifier == None && a2.classifier == Some("native"))
+          else if (a1.classifier.isEmpty && a2.classifier.isDefined)
             Some(m1)
-          else if (a1.`type` == Some("bundle") && a2.`type` == Some("jar"))
+          else if (a1.`type` == "bundle" && a2.`type` == "jar")
             Some(m1)
-          else if (a1.`type` == Some("jar") && a2.`type` == Some("bundle"))
+          else if (a1.`type` == "jar" && a2.`type` == "bundle")
             Some(m2)
           else
             None

--- a/src/test/scala/sbtwhitesource/BaseActionSpec.scala
+++ b/src/test/scala/sbtwhitesource/BaseActionSpec.scala
@@ -11,15 +11,41 @@ class BaseActionSpec extends WordSpec with Matchers {
   "The base action" should {
     "merge standard and native jars of the same artifacts" in {
       val nativeUrl = new URL("https://repo1.maven.org/maven2/com/github/jnr/jffi/1.2.16/jffi-1.2.16-native.jar")
-      val nativeArtifact: Artifact = Artifact("com.github", "jar", "jar", Some("native"), Vector(), Some(nativeUrl))
+      val nativeArtifact: Artifact = Artifact("jffi", "jar", "jar", Some("native"), Vector(), Some(nativeUrl))
       val native = ModuleInfo("com.github", "jffi", "1.2.16", Some((nativeArtifact, null)))
       
       val javaUrl = new URL("https://repo1.maven.org/maven2/com/github/jnr/jffi/1.2.16/jffi-1.2.16.jar")
-      val javaArtifact: Artifact = Artifact("com.github", "jar", "jar", None, Vector(), Some(javaUrl))
+      val javaArtifact: Artifact = Artifact("jffi", "jar", "jar", None, Vector(), Some(javaUrl))
       val java = ModuleInfo("com.github", "jffi", "1.2.16", Some((javaArtifact, null)))
       
       BaseAction.mergeModuleInfo(native, java) should be(Some(java))
       BaseAction.mergeModuleInfo(java, native) should be(Some(java))
+    }
+
+    "merge platform-specific artifacts with matching platform-independent artifacts" in {
+      val nativeUrl = new URL("https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.42.Final/netty-transport-native-epoll-4.1.42.Final-linux-x86_64.jar")
+      val nativeArtifact: Artifact = Artifact("netty-transport-native-epoll", "jar", "jar", Some("linux-x86_64"), Vector(), Some(nativeUrl))
+      val native = ModuleInfo("io.netty", "netty-transport-native-epoll", "4.1.42.Final", Some((nativeArtifact, null)))
+
+      val javaUrl = new URL("https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.42.Final/netty-transport-native-epoll-4.1.42.Final.jar")
+      val javaArtifact: Artifact = Artifact("netty-transport-native-epoll", "jar", "jar", None, Vector(), Some(javaUrl))
+      val java = ModuleInfo("io.netty", "netty-transport-native-epoll", "4.1.42.Final", Some((javaArtifact, null)))
+
+      BaseAction.mergeModuleInfo(native, java) should be(Some(java))
+      BaseAction.mergeModuleInfo(java, native) should be(Some(java))
+    }
+
+    "upgrade 'jar' to 'bundle' when both types are present" in {
+      val url = new URL("https://repo1.maven.org/maven2/com/example/osgi/fake-osgi-bundle/1.0.0/fake-osgi-bundle-1.0.0.jar")
+
+      val bundleArtifact: Artifact = Artifact("fake-osgi-bundle", "bundle", "jar", None, Vector(), Some(url))
+      val bundle = ModuleInfo("com.example.osgi", "fake-osgi-bundle", "1.0.0", Some((bundleArtifact, null)))
+
+      val jarArtifact: Artifact = Artifact("fake-osgi-bundle", "jar", "jar", None, Vector(), Some(url))
+      val jar = ModuleInfo("com.example.osgi", "fake-osgi-bundle", "1.0.0", Some((jarArtifact, null)))
+
+      BaseAction.mergeModuleInfo(bundle, jar) should be(Some(bundle))
+      BaseAction.mergeModuleInfo(jar, bundle) should be(Some(bundle))
     }
   }
 }


### PR DESCRIPTION
- Classifiers may have values other than "native".
- Artifact.type is a String, not an Option[String].
- Fill in missing tests.

Ref:

- #58
- #59
- #68 
- https://github.com/lagom/lagom/issues/2331